### PR TITLE
https://github.com/Fumiya0719/pref-population-changes/issues/3 への対応

### DIFF
--- a/src/assets/plugins/setApiKey.ts
+++ b/src/assets/plugins/setApiKey.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 const axios_instance = axios.create()
 axios_instance.interceptors.request.use((config) => {
     config.headers = {
-        'X-API-KEY': '' /* ここにAPIKeyが入る */,
+        'X-API-KEY': process.env.VUE_APP_RESAS_API_KEY,
     }
     return config
 })


### PR DESCRIPTION
- .env.localにAPIKeyをセットした環境変数を用意
- setApiKey.tsにてリクエストヘッダにその環境変数を設定
- Vercelで同様の環境変数を直接指定
これで恐らくデプロイ時に正しくAPIKeyが設定されて都道府県情報が得られると思われる。