### PR TITLE
人口情報(都道府県情報継承)のInterfaceを別途作成し適用

### DIFF
--- a/src/assets/ts/interfaces/interfaces.ts
+++ b/src/assets/ts/interfaces/interfaces.ts
@@ -8,11 +8,14 @@ export interface PopulationInfo {
     data: PopulationByAge[]
 }
 
-export interface PrefInfo {
+export interface Pref {
     prefCode: number
     prefName: string
     prefId: string
-    population?: PopulationInfo[]
+}
+
+export interface PrefInfo extends Pref {
+    population: PopulationInfo[]
 }
 
 export interface PrefCharts {

--- a/src/components/molecules/PrefectureList.vue
+++ b/src/components/molecules/PrefectureList.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import '@/assets/css/organisms/prefecture.css'
-import { PrefInfo } from '@/assets/ts/interfaces/interfaces'
+import { Pref } from '@/assets/ts/interfaces/interfaces'
 import { toRefs } from 'vue'
 
 interface Props {
-    prefectures: PrefInfo[]
-    selectedPrefectures: PrefInfo[]
+    prefectures: Pref[]
+    selectedPrefectures: Pref[]
 }
 
 interface Emits {
-    (emit: 'onSelectPrefecture', pref: PrefInfo): void
+    (emit: 'onSelectPrefecture', pref: Pref): void
 }
 
 const props = defineProps<Props>()
@@ -19,7 +19,7 @@ const { prefectures } = toRefs(props)
 const { selectedPrefectures } = toRefs(props)
 
 // 都道府県の選択状態に変更があった場合、PrefectureComponentに選択した都道府県を送る
-const onSelectPrefecture = (pref: PrefInfo): void => {
+const onSelectPrefecture = (pref: Pref): void => {
     emit('onSelectPrefecture', pref)
 }
 </script>

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -16,10 +16,7 @@ const { prefPopulation } = toRefs(props)
 // グラフ描画用の人口情報を生成
 const generatePrefCharts = (prefs: PrefInfo[]): PrefCharts[] => {
     return prefs.map((pref) => {
-        const populationList =
-            pref.population === undefined
-                ? []
-                : pref.population[0].data.map((v) => v.value)
+        const populationList = pref.population[0].data.map((v) => v.value)
 
         return {
             name: pref.prefName,
@@ -44,13 +41,15 @@ watchEffect(() => {
 </script>
 <template>
     <section class="chart-area">
-        <VueHighcharts
-            v-if="prefPopulation.length > 0 && renderComponent"
-            type="chart"
-            :options="chartOptions"
-        />
-        <div v-else>
-            <p>都道府県が選択されていません。</p>
+        <div>
+            <VueHighcharts
+                v-if="prefPopulation.length > 0 && renderComponent"
+                type="chart"
+                :options="chartOptions"
+            />
+            <div v-else>
+                <p>都道府県が選択されていません。</p>
+            </div>
         </div>
     </section>
 </template>

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -41,6 +41,7 @@ watchEffect(() => {
 </script>
 <template>
     <section class="chart-area">
+        <h2>都道府県の人口変化</h2>
         <div>
             <VueHighcharts
                 v-if="prefPopulation.length > 0 && renderComponent"

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -3,7 +3,11 @@ import '@/assets/css/organisms/prefecture.css'
 import PrefectureList from '@/components/molecules/PrefectureList.vue'
 import endpoint from '@/assets/ts/endpoint'
 import getPrefInfo from '@/components/api/getPrefInfo'
-import { PrefInfo, PopulationInfo } from '@/assets/ts/interfaces/interfaces'
+import {
+    Pref,
+    PrefInfo,
+    PopulationInfo,
+} from '@/assets/ts/interfaces/interfaces'
 import { ref, onMounted } from 'vue'
 
 interface Emits {
@@ -12,9 +16,9 @@ interface Emits {
 const emit = defineEmits<Emits>()
 
 // 都道府県一覧
-const prefectures = ref<PrefInfo[]>([])
+const prefectures = ref<Pref[]>([])
 // 選択された都道府県一覧
-const selectedPrefectures = ref<PrefInfo[]>([])
+const selectedPrefectures = ref<Pref[]>([])
 // 都道府県の人口情報
 const prefPopulation = ref<PrefInfo[]>([])
 
@@ -34,7 +38,7 @@ const getPrefPopulation = async (
 }
 
 // 配列が都道府県コード順になるように該当の都道府県の挿入位置を取得する
-const getPushPrefInfoAt = (haystack: PrefInfo[], needle: PrefInfo): number => {
+const getPushPrefInfoAt = (haystack: Pref[], needle: Pref): number => {
     const index = haystack.findIndex(
         (stack) => stack.prefCode > needle.prefCode
     )
@@ -42,7 +46,7 @@ const getPushPrefInfoAt = (haystack: PrefInfo[], needle: PrefInfo): number => {
 }
 
 // 都道府県の選択状態に変更があった場合、選択内容と人口動態内容を変更
-const onSelectPrefecture = async (pref: PrefInfo) => {
+const onSelectPrefecture = async (pref: Pref) => {
     const prefIndex = selectedPrefectures.value.indexOf(pref)
     if (prefIndex !== -1) {
         // checkboxで選択が解除された場合削除
@@ -69,15 +73,15 @@ const onSelectPrefecture = async (pref: PrefInfo) => {
 }
 
 // viewでlabelとinputの接続のためのidを作成する
-const setPrefId = (prefs: PrefInfo[]): PrefInfo[] => {
-    prefs.map((pref: PrefInfo, index: number) => {
+const setPrefId = (prefs: Pref[]): Pref[] => {
+    prefs.map((pref: Pref, index: number) => {
         prefs[index]['prefId'] = 'pref_' + pref.prefCode
     })
     return prefs
 }
 
 // APIから都道府県一覧を取得する
-const getPrefectures = async (): Promise<PrefInfo[]> => {
+const getPrefectures = async (): Promise<Pref[]> => {
     const url = endpoint + 'api/v1/prefectures'
     return await getPrefInfo(url)
 }


### PR DESCRIPTION
Highchart単体をコンポーネントとしてMoleculesに作成しようと思ったが、
propsでHighchartのオプションデータを渡さないといけないこと(Propsの型をanyにするか全Optionに型定義をするかしないといけない)、
強制リロードのロジックをMoleculesに入れないといけないなどルール関連で問題があるのと、
PrefectureComponentと比べOption作成以外のロジックが無くコードが簡潔なので変に分離するよりそのままの方が良いと考えたので現状維持とする。
今後の機能実装でコードやviewの量が増えたら分割を考える。