### PR TITLE
全体のスタイル修正と一部バグ修正

### DIFF
--- a/src/assets/css/molecules/prefectureList.css
+++ b/src/assets/css/molecules/prefectureList.css
@@ -1,1 +1,39 @@
 @import '../organisms/prefecture.css';
+
+.checkbox-label {
+    cursor: pointer !important;
+    display: inline-block;   
+    background: hsl(196, 61%, 88%);
+    color: hsl(196, 100%, 10%);
+    box-shadow: 1.5px 1.5px hsl(196, 100%, 40%);
+    transition: all .1s;
+}
+.checkbox-label.selected {
+    background: hsl(196, 100%, 15%);
+    color: white;
+    box-shadow: inset 2px 2px 2px hsl(196, 100%, 5%);
+    transform: translate(1.5px, 1.5px);
+}
+
+.checkbox-label > input {
+    display: none;
+}
+.checkbox-label > label {
+    min-width: 80px;
+    padding: 2px 0;
+}
+
+
+.prefecture {
+    text-align: center;
+    width: 33%;
+}
+@media (min-width: 480px) and (max-width: 900px) {
+    .prefecture {
+        width: 25%;
+    }
+}
+
+.prefecture > .checkbox-label {
+    margin: 5px 0;
+}

--- a/src/assets/css/molecules/prefectureList.css
+++ b/src/assets/css/molecules/prefectureList.css
@@ -1,0 +1,1 @@
+@import '../organisms/prefecture.css';

--- a/src/assets/css/molecules/prefectureList.css
+++ b/src/assets/css/molecules/prefectureList.css
@@ -28,9 +28,12 @@
     text-align: center;
     width: 33%;
 }
-@media (min-width: 480px) and (max-width: 900px) {
+@media (min-width: 500px) and (max-width: 899px) {
     .prefecture {
         width: 25%;
+    }
+    .prefecture > .checkbox-label {
+        width: 100px;
     }
 }
 

--- a/src/assets/css/organisms/chart.css
+++ b/src/assets/css/organisms/chart.css
@@ -4,3 +4,19 @@
         width: 66%;
     }
 }
+
+.chart-detail {
+    position: relative;
+    margin: 1em auto;
+}
+
+.chart-detail > .not-selected {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+.chart-detail > .not-selected p {
+    font-size: 18px;
+    color: #888;
+}

--- a/src/assets/css/organisms/chart.css
+++ b/src/assets/css/organisms/chart.css
@@ -11,10 +11,7 @@
 }
 
 .chart-detail > .not-selected {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    text-align: center;
 }
 .chart-detail > .not-selected p {
     font-size: 18px;

--- a/src/assets/css/organisms/chart.css
+++ b/src/assets/css/organisms/chart.css
@@ -1,6 +1,6 @@
 @import '../style.css';
 @media (min-width: 900px) {
     .chart-area {
-        width: 67%;
+        width: 66%;
     }
 }

--- a/src/assets/css/organisms/header.css
+++ b/src/assets/css/organisms/header.css
@@ -3,8 +3,3 @@
 header {
     border-bottom: 2px dashed #888;
 }
-
-header h1 {
-    text-align: center;
-    font-size: 24px;
-}

--- a/src/assets/css/organisms/prefecture.css
+++ b/src/assets/css/organisms/prefecture.css
@@ -22,13 +22,14 @@
 }
         
 .pref-list {
+    user-select: none;
     display: flex;
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
     border: 1px solid #888;
     padding: 4px 0;
-    max-height: 320px;
+    max-height: 300px;
     overflow-y: auto;
 }
 @media (min-width: 900px) {
@@ -49,7 +50,7 @@
 }
 .pref-list::before { order: 1; }
 
-@media (min-width: 480px) and (max-width: 900px) {
+@media (min-width: 480px) and (max-width: 899px) {
     .pref-list::before, .pref-list::after { 
         width: 25%;
     }

--- a/src/assets/css/organisms/prefecture.css
+++ b/src/assets/css/organisms/prefecture.css
@@ -4,9 +4,16 @@
     都道府県一覧
 
 -------------------- */
+.pref-area {
+    padding-bottom: 1em;
+    border-bottom: 1px solid #888;
+}
+
 @media (min-width: 900px) {
     .pref-area {
         width: 33%;
+        border-bottom: none;
+        border-right: 1px solid #888;
     }
 }
 
@@ -19,7 +26,31 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
+    border: 1px solid #888;
+    padding: 4px 0;
+    max-height: 320px;
+    overflow-y: auto;
 }
-.pref-list > .prefecture {
+@media (min-width: 900px) {
+    .pref-list {
+        border: none;
+        padding: 0;
+        max-height: none;
+        overflow-y: visible;
+    }
+}
+
+/* 3,4カラムレイアウトflexboxの左揃え */
+.pref-list::before, .pref-list::after {
+    content: "";
     width: 33%;
+    display: block;
+    height: 0;
+}
+.pref-list::before { order: 1; }
+
+@media (min-width: 480px) and (max-width: 900px) {
+    .pref-list::before, .pref-list::after { 
+        width: 25%;
+    }
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -6,11 +6,21 @@
 #app {
     max-width: 1280px;
     margin: 0 auto;
+    padding: 0 8px;
     font-family: 'Yu Gothic Medium', '游ゴシック Medium', sans-serif;
 }
 
 h1, h2, h3 {
     margin: 8px 0;
+}
+
+h1 {
+    text-align: center;
+    font-size: 24px;
+}
+
+h2 {
+    font-size: 20px;
 }
 
 p {

--- a/src/assets/ts/chartOptions.ts
+++ b/src/assets/ts/chartOptions.ts
@@ -1,9 +1,20 @@
 const chartOptions = {
+    chart: {
+        scrollablePlotArea: {
+            minWidth: 600,
+            scrollPositionX: 1,
+        },
+    },
     title: {
-        text: '都道府県の人口動態',
+        text: '',
     },
     xAxis: {
         categories: [...Array(18)].map((_, index) => 1960 + index * 5),
+        plotLines: [...Array(18)].map((_, index) => ({
+            value: index,
+            width: 1,
+            color: '#888',
+        })),
     },
     yAxis: {
         title: {
@@ -21,7 +32,7 @@ const chartOptions = {
         valueSuffix: '人',
     },
     legend: {
-        layout: 'vertical',
+        layout: 'horizontal',
         align: 'right',
         verticalAlign: 'middle',
         borderWidth: 0,
@@ -36,11 +47,10 @@ const chartOptions = {
         rules: [
             {
                 condition: {
-                    maxWidth: 600,
+                    maxWidth: 900,
                 },
                 chartOptions: {
                     legend: {
-                        layout: 'horizontal',
                         align: 'center',
                         verticalAlign: 'bottom',
                     },

--- a/src/components/molecules/PrefectureCheckbox.vue
+++ b/src/components/molecules/PrefectureCheckbox.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import '@/assets/css/organisms/prefecture.css'
+import '@/assets/css/molecules/prefectureList.css'
 import { Pref } from '@/assets/ts/interfaces/interfaces'
 import { toRefs } from 'vue'
 
 interface Props {
-    prefectures: Pref[]
+    prefecture: Pref
     selectedPrefectures: Pref[]
 }
 
@@ -15,7 +15,7 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
-const { prefectures } = toRefs(props)
+const { prefecture } = toRefs(props)
 const { selectedPrefectures } = toRefs(props)
 
 // 都道府県の選択状態に変更があった場合、PrefectureComponentに選択した都道府県を送る
@@ -24,11 +24,7 @@ const onSelectPrefecture = (pref: Pref): void => {
 }
 </script>
 <template>
-    <div
-        class="prefecture"
-        v-for="prefecture in prefectures"
-        :key="prefecture.prefCode"
-    >
+    <div class="checkbox-label-common">
         <input
             type="checkbox"
             v-model="selectedPrefectures"

--- a/src/components/molecules/PrefectureCheckbox.vue
+++ b/src/components/molecules/PrefectureCheckbox.vue
@@ -24,16 +24,23 @@ const onSelectPrefecture = (pref: Pref): void => {
 }
 </script>
 <template>
-    <div class="checkbox-label-common">
-        <input
-            type="checkbox"
-            v-model="selectedPrefectures"
-            :value="prefecture"
-            :id="prefecture.prefId"
-            @click="onSelectPrefecture(prefecture)"
-        />
-        <label :for="prefecture.prefId">
-            {{ prefecture.prefName }}
-        </label>
+    <div class="prefecture">
+        <div
+            :class="[
+                selectedPrefectures.includes(prefecture) ? 'selected' : '',
+                'checkbox-label',
+            ]"
+        >
+            <input
+                type="checkbox"
+                v-model="selectedPrefectures"
+                :value="prefecture"
+                :id="prefecture.prefId"
+                @click="onSelectPrefecture(prefecture)"
+            />
+            <label :for="prefecture.prefId">
+                {{ prefecture.prefName }}
+            </label>
+        </div>
     </div>
 </template>

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -41,7 +41,7 @@ watchEffect(() => {
 </script>
 <template>
     <section class="chart-area">
-        <h2>都道府県の人口変化</h2>
+        <h2>選択した都道府県の年別人口変化</h2>
         <div class="chart-detail">
             <VueHighcharts
                 class="chart"

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -42,13 +42,13 @@ watchEffect(() => {
 <template>
     <section class="chart-area">
         <h2>都道府県の人口変化</h2>
-        <div>
+        <div class="chart-detail">
             <VueHighcharts
                 v-if="prefPopulation.length > 0 && renderComponent"
                 type="chart"
                 :options="chartOptions"
             />
-            <div v-else>
+            <div v-else class="not-selected">
                 <p>都道府県が選択されていません。</p>
             </div>
         </div>

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -44,6 +44,7 @@ watchEffect(() => {
         <h2>都道府県の人口変化</h2>
         <div class="chart-detail">
             <VueHighcharts
+                class="chart"
                 v-if="prefPopulation.length > 0 && renderComponent"
                 type="chart"
                 :options="chartOptions"

--- a/src/components/organisms/HeaderComponent.vue
+++ b/src/components/organisms/HeaderComponent.vue
@@ -4,6 +4,6 @@ import '@/assets/css/organisms/header.css'
 
 <template>
     <header>
-        <h1>各都道府県の年代別人口動態</h1>
+        <h1>各都道府県の年別人口変化</h1>
     </header>
 </template>

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -97,7 +97,6 @@ onMounted(async () => {
         <h2>都道府県を選択</h2>
         <div class="pref-list">
             <PrefectureCheckbox
-                class="prefecture"
                 v-for="prefecture in prefectures"
                 :key="prefecture.prefCode"
                 :prefecture="prefecture"

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -48,6 +48,7 @@ const getPushPrefInfoAt = (haystack: Pref[], needle: Pref): number => {
 // 都道府県の選択状態に変更があった場合、選択内容と人口動態内容を変更
 const onSelectPrefecture = async (pref: Pref) => {
     const prefIndex = selectedPrefectures.value.indexOf(pref)
+    console.log(prefIndex)
     if (prefIndex !== -1) {
         // checkboxで選択が解除された場合削除
         selectedPrefectures.value.splice(prefIndex, 1)
@@ -60,7 +61,7 @@ const onSelectPrefecture = async (pref: Pref) => {
             pref
         )
         prefPopulation.value.splice(
-            getPushPrefInfoAt(selectedPrefectures.value, pref),
+            getPushPrefInfoAt(prefPopulation.value, pref),
             0,
             {
                 ...pref,
@@ -70,6 +71,7 @@ const onSelectPrefecture = async (pref: Pref) => {
     }
 
     emit('setPrefPopulation', prefPopulation.value)
+    console.log(selectedPrefectures.value)
 }
 
 // viewでlabelとinputの接続のためのidを作成する

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import '@/assets/css/organisms/prefecture.css'
-import PrefectureList from '@/components/molecules/PrefectureList.vue'
+import PrefectureCheckbox from '@/components/molecules/PrefectureCheckbox.vue'
 import endpoint from '@/assets/ts/endpoint'
 import getPrefInfo from '@/components/api/getPrefInfo'
 import {
@@ -96,8 +96,11 @@ onMounted(async () => {
     <section class="pref-area">
         <h2>都道府県を選択</h2>
         <div class="pref-list">
-            <PrefectureList
-                :prefectures="prefectures"
+            <PrefectureCheckbox
+                class="prefecture"
+                v-for="prefecture in prefectures"
+                :key="prefecture.prefCode"
+                :prefecture="prefecture"
                 :selectedPrefectures="selectedPrefectures"
                 @onSelectPrefecture="onSelectPrefecture"
             />


### PR DESCRIPTION
- 全体のスタイルを見やすいように作成
- 都道府県のチェックボックスをボタンの見た目にして状態を分かりやすくした
- スマホ等画面幅が狭い場合はグラフを横スクロールできるように
- グラフの縦軸を表示してどの年代の人口か分かりやすくした
- 都道府県の選択解除時に異なる都道府県が配列から消去されていた問題を修正
- その他表示文字の変更など

確認している不具合
同じチェックボックスを連打すると選択解除されているのに配列にデータがある状態(またはその逆)になることがある。
恐らくaxiosでデータ取得に非同期通信を使っているのが原因

残りやった方が良い追加機能
- 都道府県一覧を地域ごとに分け、地域を選択するとその地域の都道府県が一気に選択・解除される機能
- radioボタンでRESASAPIでとれる人口情報を切り替えてグラフに反映させる(現在は総人口のみだが、年代別人口も取れるので)