### PR TITLE
API取得関連のバグ・エラーに対する対応

### DIFF
--- a/src/assets/css/molecules/prefectureList.css
+++ b/src/assets/css/molecules/prefectureList.css
@@ -1,7 +1,6 @@
 @import '../organisms/prefecture.css';
 
 .checkbox-label {
-    cursor: pointer !important;
     display: inline-block;   
     background: hsl(196, 61%, 88%);
     color: hsl(196, 100%, 10%);

--- a/src/assets/css/organisms/chart.css
+++ b/src/assets/css/organisms/chart.css
@@ -5,15 +5,19 @@
     }
 }
 
-.chart-detail {
+.chart-area > .chart-detail {
     position: relative;
     margin: 1em auto;
 }
+.chart-area > .chart-detail > .caption {
+    display: block;
+    text-align: right;
+}
 
-.chart-detail > .not-selected {
+.chart-area > .not-selected {
     text-align: center;
 }
-.chart-detail > .not-selected p {
+.chart-area > .not-selected p {
     font-size: 18px;
     color: #888;
 }

--- a/src/assets/css/organisms/prefecture.css
+++ b/src/assets/css/organisms/prefecture.css
@@ -22,6 +22,7 @@
 }
         
 .pref-list {
+    position: relative;
     user-select: none;
     display: flex;
     justify-content: space-between;
@@ -54,4 +55,16 @@
     .pref-list::before, .pref-list::after { 
         width: 25%;
     }
+}
+
+/* 都道府県選択時のデータ取得処理終了までcheckboxを押させないためのカバー */
+.select-disabled-cover {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    opacity: 0.3;
+    background-color: white;
 }

--- a/src/components/api/getPrefInfo.ts
+++ b/src/components/api/getPrefInfo.ts
@@ -5,11 +5,17 @@ const getPrefInfo = async (url: string, config: object = {}) => {
     return await axios
         .get(url, config)
         .then((response) => {
-            return response.data.result
+            return {
+                status: 'success',
+                content: response.data.result,
+            }
         })
         .catch((error) => {
             console.log(error)
-            return '都道府県情報を取得できませんでした。'
+            return {
+                status: 'error',
+                content: '都道府県情報を取得できませんでした。',
+            }
         })
 }
 

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -57,16 +57,15 @@ watchEffect(() => {
     <section class="chart-area">
         <h2>選択した都道府県の{{ populationName }}統計</h2>
         <PopulationTypes @setPopulationType="setPopulationType" />
-        <div class="chart-detail">
-            <VueHighcharts
-                class="chart"
-                v-if="prefPopulation.length > 0 && renderComponent"
-                type="chart"
-                :options="chartOptions"
-            />
-            <div v-else class="not-selected">
-                <p>都道府県が選択されていません。</p>
-            </div>
+        <div
+            class="chart-detail"
+            v-if="prefPopulation.length > 0 && renderComponent"
+        >
+            <VueHighcharts class="chart" type="chart" :options="chartOptions" />
+            <small class="caption">※2015年以降は推計値</small>
+        </div>
+        <div v-else class="not-selected">
+            <p>都道府県が選択されていません。</p>
         </div>
     </section>
 </template>

--- a/src/components/organisms/HeaderComponent.vue
+++ b/src/components/organisms/HeaderComponent.vue
@@ -4,6 +4,6 @@ import '@/assets/css/organisms/header.css'
 
 <template>
     <header>
-        <h1>各都道府県の年別人口変化</h1>
+        <h1>各都道府県の人口統計</h1>
     </header>
 </template>

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -33,7 +33,6 @@ const getPrefPopulation = async (
             cityCode: '-',
         },
     })
-
     return prefInfo.data
 }
 
@@ -45,8 +44,13 @@ const getPushPrefInfoAt = (haystack: Pref[], needle: Pref): number => {
     return index !== -1 ? index : haystack.length
 }
 
+// 都道府県の選択の有効状態
+const isPrefSelectable = ref<boolean>(true)
 // 都道府県の選択状態に変更があった場合、選択内容と人口動態内容を変更
-const onSelectPrefecture = async (pref: Pref) => {
+// この処理が完了するまで都道府県の選択を無効にする
+const onSelectPrefecture = async (pref: Pref): Promise<void> => {
+    isPrefSelectable.value = false
+
     const prefIndex = selectedPrefectures.value.indexOf(pref)
     if (prefIndex !== -1) {
         // checkboxで選択が解除された場合削除
@@ -70,6 +74,7 @@ const onSelectPrefecture = async (pref: Pref) => {
     }
 
     emit('setPrefPopulation', prefPopulation.value)
+    isPrefSelectable.value = true
 }
 
 // viewでlabelとinputの接続のためのidを作成する
@@ -103,6 +108,7 @@ onMounted(async () => {
                 :selectedPrefectures="selectedPrefectures"
                 @onSelectPrefecture="onSelectPrefecture"
             />
+            <div class="select-disabled-cover" v-show="!isPrefSelectable"></div>
         </div>
     </section>
 </template>

--- a/src/components/templates/PrefCharts.vue
+++ b/src/components/templates/PrefCharts.vue
@@ -6,9 +6,18 @@ import ChartComponent from '@/components/organisms/ChartComponent.vue'
 import { PrefInfo } from '@/assets/ts/interfaces/interfaces'
 import { ref } from 'vue'
 
+// API通信成功の判定と表示用のエラーメッセージ
+const isSuccessApiConnection = ref<boolean>(true)
+const apiConnectionErrorMessage = ref<string>('')
+// 子コンポーネントでのAPI通信時にエラーが発生した場合エラーメッセージを画面表示させる
+const setApiConnectionError = (message: string): void => {
+    isSuccessApiConnection.value = false
+    apiConnectionErrorMessage.value = message
+}
+
 // 都道府県の人口情報
 const prefPopulation = ref<PrefInfo[]>([])
-// 子コンポーネントから送られた都道府県の人口情報を設定
+// PrefectureComponentから送られた都道府県の人口情報を設定
 const setPrefPopulation = (prefPopulations: PrefInfo[]): void => {
     prefPopulation.value = prefPopulations
 }
@@ -16,8 +25,15 @@ const setPrefPopulation = (prefPopulations: PrefInfo[]): void => {
 
 <template>
     <HeaderComponent />
-    <main class="main-content">
-        <PrefectureComponent @setPrefPopulation="setPrefPopulation" />
+    <main class="main-content" v-if="isSuccessApiConnection">
+        <PrefectureComponent
+            @setPrefPopulation="setPrefPopulation"
+            @setApiConnectionError="setApiConnectionError"
+        />
         <ChartComponent :prefPopulation="prefPopulation" />
     </main>
+    <div v-else>
+        <p>{{ apiConnectionErrorMessage }}</p>
+        <p>お手数ですが、時間をおいてから画面を再読み込みしてください。</p>
+    </div>
 </template>


### PR DESCRIPTION
- APIから人口統計取得中は都道府県を選択できないように
- API取得エラー時取得できなかった旨を画面ひょうじするように
前者は都道府県のCheckboxを素早く2回クリックすると選択してないのにデータが入ってしまう問題の対応

その他改善点
人口統計取得後、グラフ描画する際のオプション作成処理が重たい
→ PrefectureComponentからemitで送っているデータが選択した都道府県全ての情報なので、
毎回mapでその都道府県全ての18個分の人口情報をデータ整理しているのが問題。
(つまり全都道府県を選択時は47 x 18回分処理が行われる)

当初は選択している都道府県を順番に表示するためにspliceで都道府県コード順になるようにデータを挿入していたが、
highchart.jsがそれをやってくれているので普通にpushで順不同で入れるようにしても問題ないかも