### PR TITLE
ChartComponentに送る都道府県情報を配列から単体に変更して処理速度の向上

### DIFF
--- a/src/assets/ts/chartOptions.ts
+++ b/src/assets/ts/chartOptions.ts
@@ -1,4 +1,5 @@
-const chartOptions = {
+// Highchart Componentのoptionsがany型なのでanyで指定
+const chartOptions: any = {
     chart: {
         scrollablePlotArea: {
             minWidth: 600,
@@ -38,12 +39,7 @@ const chartOptions = {
         verticalAlign: 'middle',
         borderWidth: 0,
     },
-    series: [
-        {
-            name: '',
-            data: [0],
-        },
-    ],
+    series: [],
     responsive: {
         rules: [
             {

--- a/src/assets/ts/chartOptions.ts
+++ b/src/assets/ts/chartOptions.ts
@@ -1,4 +1,5 @@
 // Highchart Componentのoptionsがany型なのでanyで指定
+// eslint-disable-next-line
 const chartOptions: any = {
     chart: {
         scrollablePlotArea: {

--- a/src/assets/ts/interfaces/interfaces.ts
+++ b/src/assets/ts/interfaces/interfaces.ts
@@ -22,3 +22,9 @@ export interface PrefCharts {
     name: string
     data: number[]
 }
+
+export interface TransferPrefInfo {
+    method: 'push' | 'remove'
+    index: number
+    prefInfo?: PrefInfo
+}

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -8,15 +8,15 @@ import {
     PrefInfo,
     PrefCharts,
 } from '@/assets/ts/interfaces/interfaces'
-import { ref, toRefs, watchEffect, nextTick } from 'vue'
+import { ref, toRefs, watch, nextTick } from 'vue'
 
 interface Props {
-    prefInfo: TransferPrefInfo | undefined
+    transferPrefInfo: TransferPrefInfo | undefined
 }
 const props = defineProps<Props>()
 
 // 都道府県人口情報
-const { prefInfo } = toRefs(props)
+const { transferPrefInfo } = toRefs(props)
 
 // 表示する人口の種類
 const populationType = ref<number>(0)
@@ -29,15 +29,13 @@ const setPopulationType = (popuType: { [key: string]: string }): void => {
 }
 
 // グラフ描画用の人口情報を生成
-const generatePrefCharts = (prefs: PrefInfo[], type: number): PrefCharts[] => {
-    return prefs.map((pref) => {
-        const populationList = pref.population[type].data.map((v) => v.value)
+const generatePrefCharts = (pref: PrefInfo, type: number): PrefCharts => {
+    const populationList = pref.population[type].data.map((v) => v.value)
 
-        return {
-            name: pref.prefName,
-            data: populationList,
-        }
-    })
+    return {
+        name: pref.prefName,
+        data: populationList,
+    }
 }
 
 // チャートを強制更新する
@@ -48,12 +46,29 @@ const forceRenderer = async () => {
     renderComponent.value = true
 }
 
+// チャートのオプション追加・削除処理
+const setChartOptions = (transfer: TransferPrefInfo): void => {
+    if (transfer.method === 'remove') {
+        chartOptions.series.splice(transfer.index, 1)
+    } else if (transfer.method === 'push' && transfer.prefInfo !== undefined) {
+        chartOptions.series.splice(
+            transfer.index,
+            0,
+            generatePrefCharts(transfer.prefInfo, populationType.value)
+        )
+    }
+}
+
+// 人口種別が変更された際既存のオプションをリセットして変更された種別の内容に変更
+watch(populationType, () => {
+    chartOptions.series
+})
+
 // 都道府県人口情報が更新された際チャートを更新
-watchEffect(() => {
-    chartOptions.series = generatePrefCharts(
-        prefPopulation.value,
-        populationType.value
-    )
+watch(transferPrefInfo, () => {
+    if (transferPrefInfo.value !== undefined) {
+        setChartOptions(transferPrefInfo.value)
+    }
     forceRenderer()
 })
 </script>
@@ -63,7 +78,7 @@ watchEffect(() => {
         <PopulationTypes @setPopulationType="setPopulationType" />
         <div
             class="chart-detail"
-            v-if="prefPopulation.length > 0 && renderComponent"
+            v-if="chartOptions.series.length > 0 && renderComponent"
         >
             <VueHighcharts class="chart" type="chart" :options="chartOptions" />
             <small class="caption">※2015年以降は推計値</small>

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -3,16 +3,20 @@ import '@/assets/css/organisms/chart.css'
 import chartOptions from '@/assets/ts/chartOptions'
 import PopulationTypes from '@/components/molecules/PopulationTypes.vue'
 import VueHighcharts from 'vue3-highcharts'
-import { PrefInfo, PrefCharts } from '@/assets/ts/interfaces/interfaces'
+import {
+    TransferPrefInfo,
+    PrefInfo,
+    PrefCharts,
+} from '@/assets/ts/interfaces/interfaces'
 import { ref, toRefs, watchEffect, nextTick } from 'vue'
 
 interface Props {
-    prefPopulation: PrefInfo[]
+    prefInfo: TransferPrefInfo | undefined
 }
 const props = defineProps<Props>()
 
 // 都道府県人口情報
-const { prefPopulation } = toRefs(props)
+const { prefInfo } = toRefs(props)
 
 // 表示する人口の種類
 const populationType = ref<number>(0)

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -39,21 +39,6 @@ const generatePrefCharts = (pref: PrefInfo, type: number): PrefCharts => {
     }
 }
 
-// チャートオプションと都道府県情報の追加・削除処理
-const setChartOptions = (transfer: TransferPrefInfo): void => {
-    if (transfer.method === 'remove') {
-        prefInfo.value.splice(transfer.index, 1)
-        chartOptions.series.splice(transfer.index, 1)
-    } else if (transfer.method === 'push' && transfer.prefInfo !== undefined) {
-        prefInfo.value.splice(transfer.index, 0, transfer.prefInfo)
-        chartOptions.series.splice(
-            transfer.index,
-            0,
-            generatePrefCharts(transfer.prefInfo, populationType.value)
-        )
-    }
-}
-
 // チャートを強制更新する
 const renderComponent = ref<boolean>(true)
 const forceRenderer = async () => {
@@ -73,8 +58,22 @@ watch(populationType, () => {
 
 // 都道府県情報の追加・削除が伝達された場合チャートオプションを更新
 watch(transferPrefInfo, () => {
-    if (transferPrefInfo.value !== undefined) {
-        setChartOptions(transferPrefInfo.value)
+    const transfer = transferPrefInfo.value
+    if (transfer !== undefined) {
+        if (transfer.method === 'remove') {
+            prefInfo.value.splice(transfer.index, 1)
+            chartOptions.series.splice(transfer.index, 1)
+        } else if (
+            transfer.method === 'push' &&
+            transfer.prefInfo !== undefined
+        ) {
+            prefInfo.value.splice(transfer.index, 0, transfer.prefInfo)
+            chartOptions.series.splice(
+                transfer.index,
+                0,
+                generatePrefCharts(transfer.prefInfo, populationType.value)
+            )
+        }
     }
     forceRenderer()
 })

--- a/src/components/organisms/ChartComponent.vue
+++ b/src/components/organisms/ChartComponent.vue
@@ -74,8 +74,9 @@ watch(transferPrefInfo, () => {
                 generatePrefCharts(transfer.prefInfo, populationType.value)
             )
         }
+
+        forceRenderer()
     }
-    forceRenderer()
 })
 </script>
 <template>

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -5,7 +5,6 @@ import endpoint from '@/assets/ts/endpoint'
 import getPrefInfo from '@/components/api/getPrefInfo'
 import {
     Pref,
-    PrefInfo,
     PopulationInfo,
     TransferPrefInfo,
 } from '@/assets/ts/interfaces/interfaces'
@@ -68,14 +67,11 @@ const onSelectPrefecture = async (pref: Pref): Promise<void> => {
         })
     } else {
         // 選択された場合人口情報と選択都道府県一覧の指定位置にデータを追加
-        selectedPrefectures.value.splice(
-            getPushPrefInfoAt(selectedPrefectures.value, pref),
-            0,
-            pref
-        )
+        const pushIndex = getPushPrefInfoAt(selectedPrefectures.value, pref)
+        selectedPrefectures.value.splice(pushIndex, 0, pref)
         emit('setPrefInfo', {
             method: 'push',
-            index: getPushPrefInfoAt(selectedPrefectures.value, pref),
+            index: pushIndex,
             prefInfo: {
                 ...pref,
                 population: await getPrefPopulation(pref.prefCode),

--- a/src/components/organisms/PrefectureComponent.vue
+++ b/src/components/organisms/PrefectureComponent.vue
@@ -7,11 +7,12 @@ import {
     Pref,
     PrefInfo,
     PopulationInfo,
+    TransferPrefInfo,
 } from '@/assets/ts/interfaces/interfaces'
 import { ref, onMounted } from 'vue'
 
 interface Emits {
-    (emit: 'setPrefPopulation', prefPopulations: PrefInfo[]): void
+    (emit: 'setPrefInfo', prefInfo: TransferPrefInfo): void
     (emit: 'setApiConnectionError', message: string): void
 }
 const emit = defineEmits<Emits>()
@@ -20,8 +21,6 @@ const emit = defineEmits<Emits>()
 const prefectures = ref<Pref[]>([])
 // 選択された都道府県一覧
 const selectedPrefectures = ref<Pref[]>([])
-// 都道府県の人口情報
-const prefPopulation = ref<PrefInfo[]>([])
 
 // API通信に失敗した場合、PrefChartsにエラーメッセージを送信
 const setApiConnectionError = (message: string): void => {
@@ -63,7 +62,10 @@ const onSelectPrefecture = async (pref: Pref): Promise<void> => {
     if (prefIndex !== -1) {
         // checkboxで選択が解除された場合削除
         selectedPrefectures.value.splice(prefIndex, 1)
-        prefPopulation.value.splice(prefIndex, 1)
+        emit('setPrefInfo', {
+            method: 'remove',
+            index: prefIndex,
+        })
     } else {
         // 選択された場合人口情報と選択都道府県一覧の指定位置にデータを追加
         selectedPrefectures.value.splice(
@@ -71,17 +73,16 @@ const onSelectPrefecture = async (pref: Pref): Promise<void> => {
             0,
             pref
         )
-        prefPopulation.value.splice(
-            getPushPrefInfoAt(prefPopulation.value, pref),
-            0,
-            {
+        emit('setPrefInfo', {
+            method: 'push',
+            index: getPushPrefInfoAt(selectedPrefectures.value, pref),
+            prefInfo: {
                 ...pref,
                 population: await getPrefPopulation(pref.prefCode),
-            }
-        )
+            },
+        })
     }
 
-    emit('setPrefPopulation', prefPopulation.value)
     isPrefSelectable.value = true
 }
 

--- a/src/components/templates/PrefCharts.vue
+++ b/src/components/templates/PrefCharts.vue
@@ -3,7 +3,7 @@ import '@/assets/css/templates/prefCharts.css'
 import HeaderComponent from '@/components/organisms/HeaderComponent.vue'
 import PrefectureComponent from '@/components/organisms/PrefectureComponent.vue'
 import ChartComponent from '@/components/organisms/ChartComponent.vue'
-import { PrefInfo } from '@/assets/ts/interfaces/interfaces'
+import { TransferPrefInfo } from '@/assets/ts/interfaces/interfaces'
 import { ref } from 'vue'
 
 // API通信成功の判定と表示用のエラーメッセージ
@@ -16,10 +16,10 @@ const setApiConnectionError = (message: string): void => {
 }
 
 // 都道府県の人口情報
-const prefPopulation = ref<PrefInfo[]>([])
+const transferPrefInfo = ref<TransferPrefInfo>()
 // PrefectureComponentから送られた都道府県の人口情報を設定
-const setPrefPopulation = (prefPopulations: PrefInfo[]): void => {
-    prefPopulation.value = prefPopulations
+const setPrefInfo = (prefInfo: TransferPrefInfo): void => {
+    transferPrefInfo.value = prefInfo
 }
 </script>
 
@@ -27,10 +27,10 @@ const setPrefPopulation = (prefPopulations: PrefInfo[]): void => {
     <HeaderComponent />
     <main class="main-content" v-if="isSuccessApiConnection">
         <PrefectureComponent
-            @setPrefPopulation="setPrefPopulation"
+            @setPrefInfo="setPrefInfo"
             @setApiConnectionError="setApiConnectionError"
         />
-        <ChartComponent :prefPopulation="prefPopulation" />
+        <ChartComponent :prefInfo="transferPrefInfo" />
     </main>
     <div v-else>
         <p>{{ apiConnectionErrorMessage }}</p>

--- a/src/components/templates/PrefCharts.vue
+++ b/src/components/templates/PrefCharts.vue
@@ -30,7 +30,7 @@ const setPrefInfo = (prefInfo: TransferPrefInfo): void => {
             @setPrefInfo="setPrefInfo"
             @setApiConnectionError="setApiConnectionError"
         />
-        <ChartComponent :prefInfo="transferPrefInfo" />
+        <ChartComponent :transferPrefInfo="transferPrefInfo" />
     </main>
     <div v-else>
         <p>{{ apiConnectionErrorMessage }}</p>


### PR DESCRIPTION
- 都道府県＋人口情報をChart, Prefectureの両コンポーネントで保持していたのをChartComponentのみにした
- 親コンポーネント経由で送るデータを全ての都道府県＋人口情報から選択したもの単体のみに変更
    - 削除・追加どちらかの命令とインデックスを付与した状態で送信する
    - ↑はcheckboxの状態とチャートに表示する都道府県を連動させるため
- チャートの表示を設定するchartOptionsをany型に
    - 都道府県＋人口情報を格納するseriesプロパティの初期値を空の配列にするとnever型になる問題への対応
    - 外部モジュールのHighchartコンポーネントに送るoptionもany型なので問題無いと思われる

多少コードの可読性が下がったのと0.5ms程度しか変化がなかったが、データの棲み分けの点ではこちらの方が良いと思う。
一応archive_transfer-arrayブランチに配列を送る場合のコードを残しておく